### PR TITLE
Fix issue with createCount function

### DIFF
--- a/src/typescript/view/twitter-utils.ts
+++ b/src/typescript/view/twitter-utils.ts
@@ -17,10 +17,11 @@ export const colorizeSelectedText = (tweetText: string): string => {
 };
 
 export const createCount = (count: number): string => {
-  if (!count) {
+  if (!count && count !== 0) {
     throw new Error(
       'Count argument is missing. A number for count must be provided.'
     );
   }
+
   return count.toString();
 };


### PR DESCRIPTION
ISSUE: createCount function was throwing an error for an argument that
had a value of 0

FIX: Added a condition that checks for the value of 0. Now an error
will only be thrown when the argument for count is null